### PR TITLE
[figma]:update to 0.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tower-icon",
-  "version": "0.1.3",
+  "version": "0.1.5",
   "description": "Icon automation workflow with Figma",
   "main": "dist/index.js",
   "module": "build/index.js",


### PR DESCRIPTION
将 icon frame 拖至顶级和次级目录，并测试命名结构。